### PR TITLE
Devops-5191: amq processes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ transport:
   name: sftp
 
 platforms:
-  - name: centos-7.4
+  - name: centos-7.5
 
 verifier:
   name: serverspec

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "talend-activemq",
-  "version": "0.2.0",
+  "version": "0.3.7",
   "author": "talend",
   "summary": "Module managing ActiveMQ",
   "license": "MIT",

--- a/spec/acceptance/activemq_spec.rb
+++ b/spec/acceptance/activemq_spec.rb
@@ -16,6 +16,11 @@ describe 'activemq' do
     describe port(5432) do
       it { should be_listening }
     end
+
+    describe command('/bin/systemctl --no-pager show activemq.service') do
+      its(:stdout) { should include 'LimitNOFILE=64000' }
+      its(:stdout) { should include 'LimitNPROC=64000' }
+    end
   end
 
   context 'when activemq-security-plugin installed and configured' do

--- a/templates/activemq.service.erb
+++ b/templates/activemq.service.erb
@@ -7,6 +7,8 @@ PIDFile=/opt/activemq/data/activemq.pid
 ExecStart=/opt/activemq/bin/activemq start --extdir lib/tipaas
 ExecReload=/opt/activemq/bin/activemq restart --extdir lib/tipaas
 ExecStop=/opt/activemq/bin/activemq kill
+LimitNPROC=64000
+LimitNOFILE=64000
 
 [Install]
 Alias=activemq


### PR DESCRIPTION
locally tested:
```
 ./scripts/local_dev_tests.sh -t default-centos-75
...
activemq
  when activemq is running
    Service "activemq"
      should be enabled
      should be running
    Port "8161"
      should be listening
    Port "5432"
      should be listening
    Command "/bin/systemctl --no-pager show activemq.service"
      stdout
        should include "LimitNOFILE=64000"
      stdout
        should include "LimitNPROC=64000"
  when activemq-security-plugin installed and configured
    Package "activemq-security-plugin"
      should be installed
    File "/opt/activemq/conf/activemq.xml"
      content
        should include "<bean id=\"tipaasSecurityPlugin\" class=\"org.talend.ipaas.rt.amq.security.TipaasSecurityPlugin\""
      content
        should include "<property name=\"activemqSecurityURL\" value=\"http://localhost:9999/activemq-security-service/authenticate"
      content
        should include "<property name=\"refreshInterval\" value=\"60000\" />"
  User "activemq"
    should exist
    should belong to group "activemq"
  Group "activemq"
    should exist
  File "/opt/activemq/conf/jetty-realm.properties"
    content
      should include "testadmin: testpassword, admin"

Finished in 1.26 seconds (files took 15.29 seconds to load)
14 examples, 0 failures
...
```