### PR TITLE
Devops-5430: breaking changes for activemq 5.15.7+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+.ruby-version
 .bundle/
 .idea/
 .reviewboardrc

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -5,7 +5,7 @@ packagecloud::repo { 'talend/other':
   master_token => $packagecloud_master_token
 } ->
 class { 'postgresql::globals':
-  version             => '9.3',
+  version             => '9.5',
   encoding            => 'UTF8',
   locale              => 'en_NG',
   manage_package_repo => true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,20 +1,22 @@
 class activemq::config (
 
-  $persistence           = $activemq::persistence,
-  $zk_nodes              = $activemq::zk_nodes,
-  $zk_password           = $activemq::zk_password,
-  $pg_host               = $activemq::pg_host,
-  $pg_port               = $activemq::pg_port,
-  $pg_db                 = $activemq::pg_db,
-  $pg_username           = $activemq::pg_username,
-  $pg_password           = $activemq::pg_password,
-  $pg_init_connections   = $activemq::pg_init_connections,
-  $pg_max_connections    = $activemq::pg_max_connections,
-  $auth_url              = $activemq::auth_url,
-  $auth_refresh_interval = $activemq::auth_refresh_interval,
-  $brokers               = $activemq::brokers,
-  $jetty_admin_user      = $activemq::jetty_admin_user,
-  $jetty_admin_password  = $activemq::jetty_admin_password
+  $persistence              = $activemq::persistence,
+  $zk_nodes                 = $activemq::zk_nodes,
+  $zk_password              = $activemq::zk_password,
+  $pg_host                  = $activemq::pg_host,
+  $pg_port                  = $activemq::pg_port,
+  $pg_db                    = $activemq::pg_db,
+  $pg_username              = $activemq::pg_username,
+  $pg_password              = $activemq::pg_password,
+  $pg_init_connections      = $activemq::pg_init_connections,
+  $pg_max_connections       = $activemq::pg_max_connections,
+  $auth_url                 = $activemq::auth_url,
+  $auth_refresh_interval    = $activemq::auth_refresh_interval,
+  $brokers                  = $activemq::brokers,
+  $jetty_admin_user         = $activemq::jetty_admin_user,
+  $jetty_admin_password     = $activemq::jetty_admin_password,
+  $jetty_server_min_threads = $activemq::jetty_server_min_threads,
+  $jetty_server_max_threads = $activemq::jetty_server_max_threads,
 ) {
 
   $brokers_list      = split($brokers, ',')
@@ -27,6 +29,10 @@ class activemq::config (
 
   file { '/opt/activemq/conf/activemq.xml':
     content => template('activemq/activemq.xml.erb')
+  }
+
+  file { '/opt/activemq/conf/jetty-server.xml':
+    content => template('activemq/jetty-server.xml.erb')
   }
 
   file { '/opt/activemq/conf/jetty-realm.properties':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,9 @@ class activemq (
   $persistence_pg_password         = undef,
   $ams_security_version            = 'latest',
   $jetty_admin_user                = 'admin',
-  $jetty_admin_password            = 'admin'
+  $jetty_admin_password            = 'admin',
+  $jetty_server_min_threads        = '10',
+  $jetty_server_max_threads        = '1000',
 ) {
 
   class { '::activemq::install':
@@ -39,5 +41,4 @@ class activemq (
   contain ::activemq::install
   contain ::activemq::config
   contain ::activemq::service
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
   "name": "talend-activemq",
-  "version": "0.3.7",
+  "version": "0.4",
   "author": "talend",
-  "summary": "Module managing ActiveMQ",
+  "summary": "Module managing ActiveMQ need at least ActiveMQ 5.15.7",
   "license": "MIT",
   "source": "https://github.com/Talend/puppet-activemq",
   "project_page": "https://github.com/Talend/puppet-activemq",
@@ -15,4 +15,3 @@
     {"name":"puppetlabs-tomcat", "version_requirement": "1.x"}
   ]
 }
-

--- a/spec/acceptance/activemq_spec.rb
+++ b/spec/acceptance/activemq_spec.rb
@@ -57,6 +57,10 @@ describe 'activemq' do
     its(:content) { should include '<Set name="minThreads">10</Set>' }
   end
 
+  describe file('/opt/activemq/data/activemq.log') do
+    its(:content) { should include 'Configuring Jetty server using /opt/activemq/conf/jetty-server.xml' }
+  end
+
    describe command('/usr/bin/curl -s http://localhost:8080') do
      its(:exit_status) { should eq 0 }
      its(:stdout) { should include 'No clientID header specified' }

--- a/spec/acceptance/activemq_spec.rb
+++ b/spec/acceptance/activemq_spec.rb
@@ -47,4 +47,20 @@ describe 'activemq' do
   describe file('/opt/activemq/conf/jetty-realm.properties') do
     its(:content) { should include 'testadmin: testpassword, admin' }
   end
+
+  describe file('/opt/activemq/conf/activemq.xml') do
+    its(:content) { should include '<!-- File managed by Puppet, do not modify-->' }
+  end
+
+  describe file('/opt/activemq/conf/jetty-server.xml') do
+    its(:content) { should include '<!-- File managed by Puppet, do not modify-->' }
+    its(:content) { should include '<Set name="minThreads">10</Set>' }
+  end
+
+   describe command('/usr/bin/curl -s http://localhost:8080') do
+     its(:exit_status) { should eq 0 }
+     its(:stdout) { should include 'No clientID header specified' }
+     its(:stdout) { should include 'Powered by Jetty' }
+   end
+
 end

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -14,6 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
+<!-- File managed by Puppet, do not modify-->
 <!-- START SNIPPET: example -->
 <beans
   xmlns="http://www.springframework.org/schema/beans"
@@ -199,7 +200,7 @@
             <!-- DOS protection, limit concurrent connections to 5000 and frame size to 100MB -->
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=5000&amp;wireFormat.maxFrameSize=104857600"/>
             <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=5000&amp;wireFormat.maxFrameSize=104857600"/>
-            <transportConnector name="http" uri="http://0.0.0.0:8080"/>
+            <transportConnector name="http" uri="http://0.0.0.0:8080?jetty.config=/opt/activemq/conf/jetty-server.xml"/>
         </transportConnectors>
 
         <!-- destroy the spring context on shutdown to stop jetty -->

--- a/templates/jetty-server.xml.erb
+++ b/templates/jetty-server.xml.erb
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure.dtd">
+<!-- File managed by Puppet, do not modify-->
+<Configure id="server" class="org.eclipse.jetty.server.Server">
+    <Arg>
+        <New class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+            <Set name="minThreads"><%= @jetty_server_min_threads %></Set>
+            <Set name="maxThreads"><%= @jetty_server_max_threads %></Set>
+        </New>
+    </Arg>
+</Configure>


### PR DESCRIPTION
tested locally:
```
./scripts/local_dev_tests.sh -t default-centos-75
[...]
activemq
  when activemq is running
    Service "activemq"
      should be enabled
      should be running
    Port "8161"
      should be listening
    Port "5432"
      should be listening
    Command "/bin/systemctl --no-pager show activemq.service"
      stdout
        should include "LimitNOFILE=64000"
      stdout
        should include "LimitNPROC=64000"
  when activemq-security-plugin installed and configured
    Package "activemq-security-plugin"
      should be installed
    File "/opt/activemq/conf/activemq.xml"
      content
        should include "<bean id=\"tipaasSecurityPlugin\" class=\"org.talend.ipaas.rt.amq.security.TipaasSecurityPlugin\""
      content
        should include "<property name=\"activemqSecurityURL\" value=\"http://localhost:9999/activemq-security-service/authenticate"
      content
        should include "<property name=\"refreshInterval\" value=\"60000\" />"
  User "activemq"
    should exist
    should belong to group "activemq"
  Group "activemq"
    should exist
  File "/opt/activemq/conf/jetty-realm.properties"
    content
      should include "testadmin: testpassword, admin"
  File "/opt/activemq/conf/activemq.xml"
    content
      should include "<!-- File managed by Puppet, do not modify-->"
  File "/opt/activemq/conf/jetty-server.xml"
    content
      should include "<!-- File managed by Puppet, do not modify-->"
    content
      should include "<Set name=\"minThreads\">10</Set>"
  File "/opt/activemq/data/activemq.log"
    content
      should include "Configuring Jetty server using /opt/activemq/conf/jetty-server.xml"
  Command "/usr/bin/curl -s http://localhost:8080"
    exit_status
      should eq 0
    stdout
      should include "No clientID header specified"
    stdout
      should include "Powered by Jetty"

Finished in 1.64 seconds (files took 15.29 seconds to load)
21 examples, 0 failures

       Finished verifying <default-centos-75> (0m17.27s).
-----> Destroying <default-centos-75>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <default-centos-75> destroyed.
       Finished destroying <default-centos-75> (0m3.17s).
       Finished testing <default-centos-75> (4m13.56s).
-----> Kitchen is finished. (4m13.83s)
```