### PR TITLE
DEVOPS-4498: ensure ams_security_version is not empty string

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 class activemq::install (
 
   $version              = $activemq::version,
-  $ams_security_version = $activemq::ams_security_version
+  $ams_security_version = pick($activemq::ams_security_version, 'latest')
 
 ) {
 


### PR DESCRIPTION
Unfortunately retrieving value from facter returns empty string if not specified, but not undef.
Tested by local test run