### PR TITLE
DEVOPS-7434: change database spooler

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "talend-activemq",
-  "version": "0.4",
+  "version": "0.4.5",
   "author": "talend",
   "summary": "Module managing ActiveMQ need at least ActiveMQ 5.15.7",
   "license": "MIT",

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -29,23 +29,25 @@
         </property>
     </bean>
 
-   <!-- Allows accessing the server log -->
+    <!-- Allows accessing the server log -->
     <bean id="logQuery" class="io.fabric8.insight.log.log4j.Log4jLogQuery"
           lazy-init="false" scope="singleton"
           init-method="start" destroy-method="stop">
     </bean>
 
 <% if @persistence == 'postgres' -%>
-   <!-- Configures connection to the PostgreSQL used for persistence -->
-    <bean id="postgres-persist-ds" class="org.postgresql.ds.PGPoolingDataSource" destroy-method="close">
-        <property name="dataSourceName" value="postgresPresistence"/>
-        <property name="serverName" value="<%= @persistence_pg_host %>"/>
-        <property name="portNumber" value="5432"/>
-        <property name="databaseName" value="activemq"/>
-        <property name="user" value="activemq"/>
+    <!-- Configures connection to the PostgreSQL used for persistence -->
+    <bean id="postgres-persist-ds" class="org.apache.commons.dbcp2.BasicDataSource">
+        <property name="driverClassName" value="org.postgresql.Driver" />
+        <property name="url" value="jdbc:postgresql://<%= @persistence_pg_host %>/activemq" />
+        <property name="username" value="activemq"/>
         <property name="password" value="<%= @persistence_pg_password %>"/>
-        <property name="initialConnections" value="<%= @pg_init_connections %>"/>
-        <property name="maxConnections" value="<%= @pg_max_connections %>"/>
+        <property name="initialSize" value="<%=  @pg_init_connections %>" />
+        <property name="maxTotal" value="<%= @pg_max_connections %>"/>
+        <property name="maxIdle" value="<%= @pg_init_connections %>"/>
+        <property name="validationQuery" value="select 1"/>
+        <property name="testWhileIdle" value="true"/>
+        <property name="timeBetweenEvictionRunsMillis" value="3000"/>
     </bean>
 <% end -%>
 
@@ -151,13 +153,13 @@
               zkPassword="<%= @zk_password %>"
               zkPath="/activemq/<%= @zk_prefix %>/leveldb-stores"
               hostname="<%= @hostname %>"
-              />
+            />
           </persistenceAdapter>
 <% elsif @persistence == 'postgres' -%>
         <persistenceAdapter>
             <jdbcPersistenceAdapter dataDirectory="${activemq.data}" dataSource="#postgres-persist-ds" lockKeepAlivePeriod="5000">
                 <locker>
-                    <lease-database-locker lockAcquireSleepInterval="10000"/>
+                    <lease-database-locker lockAcquireSleepInterval="20000" leaseHolderId="<%= @broker_name_real %>" />
                 </locker>
             </jdbcPersistenceAdapter>
         </persistenceAdapter>


### PR DESCRIPTION
local test only:
```
activemq
  when activemq is running
    Service "activemq"
      should be enabled
      should be running
    Port "8161"
      should be listening
    Port "5432"
      should be listening
    Command "/bin/systemctl --no-pager show activemq.service"
      stdout
        should include "LimitNOFILE=64000"
      stdout
        should include "LimitNPROC=64000"
  when activemq-security-plugin installed and configured
    Package "activemq-security-plugin"
      should be installed
    File "/opt/activemq/conf/activemq.xml"
      content
        should include "<bean id=\"tipaasSecurityPlugin\" class=\"org.talend.ipaas.rt.amq.security.TipaasSecurityPlugin\""
      content
        should include "<property name=\"activemqSecurityURL\" value=\"http://localhost:9999/activemq-security-service/authenticate"
      content
        should include "<property name=\"refreshInterval\" value=\"60000\" />"
  User "activemq"
    should exist
    should belong to group "activemq"
  Group "activemq"
    should exist
  File "/opt/activemq/conf/jetty-realm.properties"
    content
      should include "testadmin: testpassword, admin"
  File "/opt/activemq/conf/activemq.xml"
    content
      should include "<!-- File managed by Puppet, do not modify-->"
  File "/opt/activemq/conf/jetty-server.xml"
    content
      should include "<!-- File managed by Puppet, do not modify-->"
    content
      should include "<Set name=\"minThreads\">10</Set>"
  File "/opt/activemq/data/activemq.log"
    content
      should include "Configuring Jetty server using /opt/activemq/conf/jetty-server.xml"
  Command "/usr/bin/curl -s http://localhost:8080"
    exit_status
      should eq 0
    stdout
      should include "No clientID header specified"
    stdout
      should include "Powered by Jetty"
  Package "postgresql11"
    should be installed

Finished in 1.22 seconds (files took 15.28 seconds to load)
22 examples, 0 failures

       Finished verifying <default-centos-76> (0m16.81s).
-----> Destroying <default-centos-76>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <default-centos-76> destroyed.
       Finished destroying <default-centos-76> (0m3.07s).
       Finished testing <default-centos-76> (2m53.61s).
-----> Kitchen is finished. (2m53.90s)
```