### PR TITLE
fix(DEVOPS-8042): Start the service as non-root

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ transport:
   name: sftp
 
 platforms:
-  - name: centos-7.6
+  - name: centos-7.7
 
 verifier:
   name: serverspec

--- a/spec/acceptance/activemq_spec.rb
+++ b/spec/acceptance/activemq_spec.rb
@@ -18,6 +18,8 @@ describe 'activemq' do
     end
 
     describe command('/bin/systemctl --no-pager show activemq.service') do
+      its(:stdout) { should include 'User=activemq' }
+      its(:stdout) { should include 'PIDFile=/opt/activemq/data/activemq.pid' }
       its(:stdout) { should include 'LimitNOFILE=64000' }
       its(:stdout) { should include 'LimitNPROC=64000' }
     end

--- a/templates/activemq.env.erb
+++ b/templates/activemq.env.erb
@@ -98,7 +98,7 @@ fi
 
 # Configure a user with non root privileges, if no user is specified do not change user
 # (the entire activemq installation should be owned by this user)
-ACTIVEMQ_USER="activemq"
+# ACTIVEMQ_USER="activemq"
 
 # location of the pidfile
 # ACTIVEMQ_PIDFILE="$ACTIVEMQ_DATA/activemq.pid"

--- a/templates/activemq.service.erb
+++ b/templates/activemq.service.erb
@@ -2,13 +2,14 @@
 Description=Apache ActiveMQ
 
 [Service]
+User=activemq
 Type=forking
 PIDFile=/opt/activemq/data/activemq.pid
 <%- if @jmx_enabled -%>
-Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>'
+Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>' 'ACTIVEMQ_USER=activemq'
 <%- end -%>
-ExecStart=/opt/activemq/bin/activemq start --extdir lib/tipaas
-ExecReload=/opt/activemq/bin/activemq restart --extdir lib/tipaas
+ExecStart=/opt/activemq/bin/activemq start --extdir /opt/activemq/lib/tipaas
+ExecReload=/opt/activemq/bin/activemq restart --extdir /opt/activemq/lib/tipaas
 ExecStop=/opt/activemq/bin/activemq kill
 LimitNPROC=64000
 LimitNOFILE=64000

--- a/templates/activemq.service.erb
+++ b/templates/activemq.service.erb
@@ -3,11 +3,10 @@ Description=Apache ActiveMQ
 
 [Service]
 Type=forking
-PIDFile=/var/run/activemq/activemq.pid
+PIDFile=/opt/activemq/data/activemq.pid
 <%- if @jmx_enabled -%>
-Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>' 'ACTIVEMQ_PIDFILE=/var/run/activemq/activemq.pid'
+Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>'
 <%- end -%>
-ExecStartPre=/usr/bin/install -d -o activemq -g activemq -m 0700 /var/run/activemq
 ExecStart=/opt/activemq/bin/activemq start --extdir lib/tipaas
 ExecReload=/opt/activemq/bin/activemq restart --extdir lib/tipaas
 ExecStop=/opt/activemq/bin/activemq kill

--- a/templates/activemq.service.erb
+++ b/templates/activemq.service.erb
@@ -6,7 +6,7 @@ User=activemq
 Type=forking
 PIDFile=/opt/activemq/data/activemq.pid
 <%- if @jmx_enabled -%>
-Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>' 'ACTIVEMQ_USER=activemq'
+Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>'
 <%- end -%>
 ExecStart=/opt/activemq/bin/activemq start --extdir /opt/activemq/lib/tipaas
 ExecReload=/opt/activemq/bin/activemq restart --extdir /opt/activemq/lib/tipaas

--- a/templates/activemq.service.erb
+++ b/templates/activemq.service.erb
@@ -3,10 +3,11 @@ Description=Apache ActiveMQ
 
 [Service]
 Type=forking
-PIDFile=/opt/activemq/data/activemq.pid
+PIDFile=/var/run/activemq/activemq.pid
 <%- if @jmx_enabled -%>
-Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>'
+Environment='ACTIVEMQ_SUNJMX_START=<%= @jmx_agent_opts %>' 'ACTIVEMQ_PIDFILE=/var/run/activemq/activemq.pid'
 <%- end -%>
+ExecStartPre=/usr/bin/install -d -o activemq -g activemq -m 0700 /var/run/activemq
 ExecStart=/opt/activemq/bin/activemq start --extdir lib/tipaas
 ExecReload=/opt/activemq/bin/activemq restart --extdir lib/tipaas
 ExecStop=/opt/activemq/bin/activemq kill


### PR DESCRIPTION
Jira: [DEVOPS-8042](https://jira.talendforge.org/browse/DEVOPS-8042)

The upgrade to CentOS 7.7 add security checks when the process is started as root.

## Solution
Start the Systemd activemq.service as a user, instead of switching user inside the init script.

## Checks
This change has been tested with success using
`./scripts/local_dev_tests.sh -t role-activemq-centos-77`