### PR TITLE
Remove stomp connector

### DIFF
--- a/spec/acceptance/activemq_spec.rb
+++ b/spec/acceptance/activemq_spec.rb
@@ -32,7 +32,7 @@ describe 'activemq' do
 
     describe file('/opt/activemq/conf/activemq.xml') do
       its(:content) { should include '<transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=5000&amp;wireFormat.maxFrameSize=500000"/>' }
-      its(:content) { should include '<transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=5000&amp;wireFormat.maxFrameSize=500000"/>' }
+      its(:content) { should include '<transportConnector name="http" uri="http://0.0.0.0:8080?jetty.config=/opt/activemq/conf/jetty-server.xml&amp;wireFormat.maxFrameSize=500000"/>' }
       its(:content) { should include '<bean id="tipaasSecurityPlugin" class="org.talend.ipaas.rt.amq.security.TipaasSecurityPlugin"' }
       its(:content) { should include '<property name="activemqSecurityURL" value="http://localhost:9999/activemq-security-service/authenticate' }
       its(:content) { should include '<property name="refreshInterval" value="60000" />' }

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -198,11 +198,9 @@
             <!-- DOS protection, limit concurrent connections to 5000 and frame size to a max_frame_size (default 200kB) -->
             <%- if defined?(@max_frame_size) -%>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=5000&amp;wireFormat.maxFrameSize=<%= @max_frame_size %>"/>
-            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=5000&amp;wireFormat.maxFrameSize=<%= @max_frame_size %>"/>
             <transportConnector name="http" uri="http://0.0.0.0:8080?jetty.config=/opt/activemq/conf/jetty-server.xml&amp;wireFormat.maxFrameSize=<%= @max_frame_size %>"/>
             <%- else -%>
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=5000"/>
-            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=5000"/>
             <transportConnector name="http" uri="http://0.0.0.0:8080?jetty.config=/opt/activemq/conf/jetty-server.xml"/>
             <%- end -%>
         </transportConnectors>


### PR DESCRIPTION
```
Finished in 1.16 seconds (files took 15.29 seconds to load)
26 examples, 0 failures

       Finished verifying <default-centos-77> (0m16.74s).
-----> Destroying <default-centos-77>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <default-centos-77> destroyed.
       Finished destroying <default-centos-77> (0m2.84s).
       Finished testing <default-centos-77> (10m4.50s).
-----> Kitchen is finished. (10m4.71s)
```